### PR TITLE
build.sh: Properly get latest kext build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ function download()
  while IFS= read -r line; do
   link=$(echo $line | cut -d ',' -f 1)
   name=$(echo $line | cut -d ',' -f 2)
-  version=$(curl -s $link/latest | grep -o 'tag/[v.0-9]*' | awk -F/ '{print $2}')
+  version=$(curl -Ls -o /dev/null -w %{url_effective} $link/latest | grep -o 'tag/[v.0-9]*' | awk -F/ '{print $2}')
   echo Downloading $name version: $version...
   if [[ $(echo $link | cut -d '/' -f 4) == "acidanthera" && $(echo $link | cut -d '/' -f 6) == "releases" ]]; then
    curl -L $link/download/$version/$name-$version-RELEASE.zip > $DIR/$name.zip &


### PR DESCRIPTION
Follow the latest redirect, and get the tag version from URL through curls url_effective variable.

Previously, the version parsing would be broken and result in empty/broken 1kb zip files.